### PR TITLE
Add VSCode config for remote dev

### DIFF
--- a/.vscode/launch.shared.json
+++ b/.vscode/launch.shared.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Debug",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "${input:remoteHost}",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "${input:remoteRoot}"
+                }
+            ],
+            "justMyCode": true,
+            "preLaunchTask": "deploy-code",
+            "postDebugTask": "terminate-remote-debugger"
+        }
+    ]
+}

--- a/.vscode/tasks.shared.json
+++ b/.vscode/tasks.shared.json
@@ -1,0 +1,49 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "deploy-code",
+            "type": "shell",
+            "command": "rsync -avz -h -P --exclude-from=./.gitignore ${workspaceFolder}/ ${input:remoteHost}:${input:remoteRoot} && uv sync",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "start-remote-debugger",
+            "type": "shell",
+            "command": "ssh ${input:remoteHost} 'cd ${input:remoteRoot} && python -m debugpy --listen 0.0.0.0:5678 --wait-for-client ${relativeFile}'",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "^.*$",
+                    "file": 1,
+                    "location": 2,
+                    "message": 3
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^.*Waiting for client.*$",
+                    "endsPattern": "^.*$"
+                }
+            },
+            "dependsOn": [
+                "deploy-code"
+            ]
+        },
+        {
+            "label": "terminate-remote-debugger",
+            "type": "shell",
+            "command": "ssh ${input:remoteHost} 'pkill -f \"python -m debugpy\"'",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
WIP, untested.

Setup: create or modify `.vscode/tasks.json` to include something like

```json
{
    "version": "2.0.0",
    "inputs": [
        {
            "id": "remoteRoot",
            "type": "command",
            "command": "echo",
            "args": [
                "~/projects/hil"
            ]
        },
        {
            "id": "remoteHost",
            "type": "command",
            "command": "echo",
            "args": [
                "raspberrypi.local"
            ]
        }
    ]
}
```