### PR TITLE
Add safe remote test runner

### DIFF
--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -86,7 +86,14 @@ function run_test() {
 function serve_test_report() {
     local test_report_path="${TMP_DIR}/test-report.html"
     local controller_path=$(get_controller_path)
-    scp "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/artifacts/test-report.html" "${test_report_path}"
+    scp "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/artifacts/*" "${test_report_path}"
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        open "http://localhost:${TEST_REPORT_PORT}/test-report.html" &
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        xdg-open "http://localhost:${TEST_REPORT_PORT}/test-report.html" &
+    fi
+
     python3 -m http.server "${TEST_REPORT_PORT}" --directory "${TMP_DIR}"
 }
 

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -84,17 +84,10 @@ function run_test() {
 }
 
 function serve_test_report() {
-    local test_report_path="${TMP_DIR}/test-report.html"
     local controller_path=$(get_controller_path)
-    scp "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/artifacts/*" "${test_report_path}"
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        open "http://localhost:${TEST_REPORT_PORT}/test-report.html" &
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        xdg-open "http://localhost:${TEST_REPORT_PORT}/test-report.html" &
-    fi
-
-    python3 -m http.server "${TEST_REPORT_PORT}" --directory "${TMP_DIR}"
+    scp -r -q "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/artifacts/*" "${TMP_DIR}"
+    echo "Serving test report at http://127.0.0.1:8080/test-report.html"
+    python3 -m http.server --directory "${TMP_DIR}" --bind 127.0.0.1 "${TEST_REPORT_PORT}" >/dev/null 2>&1
 }
 
 check_ssh_connection || exit 1
@@ -106,6 +99,6 @@ run_test "$@"
 status=$?
 set -e
 
-serve_test_report
+serve_test_report || true
 
-exit $status
+exit "$status"

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -53,7 +53,12 @@ function copy_to_controller() {
         return 1
     fi
 
-    if ! rsync -aPh --exclude=.git/ --exclude-from=./.gitignore --delete "${PWD}/" "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/"; then
+    local rsync_exclude="--exclude=.git/ --exclude-from=./.gitignore"
+    if [ -f ".hilignore" ]; then
+        rsync_exclude+=" --exclude-from=./.hilignore"
+    fi
+
+    if ! rsync -aPh ${rsync_exclude} --delete "${PWD}/" "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/"; then
         echo "ERROR: Failed to copy files to controller"
         return 1
     fi

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -2,9 +2,14 @@
 
 set -euo pipefail
 
-# TODO: via CLI args
+if [[ -z "${HIL_CONTROLLER_HOST:-}" ]]; then
+    echo "ERROR: HIL_CONTROLLER_HOST environment variable must be set"
+    echo "Example: HIL_CONTROLLER_HOST=chunky-otter $0"
+    exit 1
+fi
+
+CONTROLLER_HOST="${HIL_CONTROLLER_HOST}"
 CONTROLLER_USERNAME='atopile'
-CONTROLLER_HOST="chunky-otter"
 
 LOCK_FILE="/home/atopile/.hil-lock"
 CONTROLLER_PATH_PREFIX="/home/atopile/hil/"

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -85,6 +85,7 @@ function run_test() {
 
 function serve_test_report() {
     local test_report_path="${TMP_DIR}/test-report.html"
+    local controller_path=$(get_controller_path)
     scp "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/artifacts/test-report.html" "${test_report_path}"
     python3 -m http.server "${TEST_REPORT_PORT}" --directory "${TMP_DIR}"
 }
@@ -93,8 +94,10 @@ check_ssh_connection || exit 1
 verify_in_git_repo || exit 1
 copy_to_controller || exit 1
 
+set +e
 run_test "$@"
 status=$?
+set -e
 
 serve_test_report
 

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -8,6 +8,7 @@ CONTROLLER_HOST="chunky-otter"
 
 LOCK_FILE="/home/atopile/.hil-lock"
 CONTROLLER_PATH_PREFIX="/home/atopile/hil/"
+LOCK_TIMEOUT=120
 
 trap 'cleanup' EXIT
 
@@ -18,83 +19,10 @@ function cleanup() {
     fi
 }
 
-function get_lock_contents() {
-    local username=$(whoami)
-    local hostname=$(hostname)
-    echo "$username@$hostname"
-}
-
 function get_controller_path() {
     local username=$(whoami)
     local hostname=$(hostname)
     echo "${CONTROLLER_PATH_PREFIX}/${username}@${hostname}"
-}
-
-function obtain_lock() {
-    local lock_contents=$(get_lock_contents)
-    local max_attempts=60  # 5 minutes with 5 second sleep
-    local attempt=1
-
-    echo "Attempting to obtain lock..."
-
-    while [ $attempt -le $max_attempts ]; do
-        # TOOD: atomic?
-        if ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "[ ! -f '${LOCK_FILE}' ] && echo '${lock_contents}' > '${LOCK_FILE}'" 2>/dev/null; then
-            echo "Lock obtained"
-            return 0
-        fi
-
-        local current_owner
-        current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
-            echo "ERROR: Cannot read lock file"
-            return 1
-        }
-        echo "Lock is currently held by: ${current_owner} (attempt ${attempt}/${max_attempts})"
-
-        if [ $attempt -eq $max_attempts ]; then
-            echo "ERROR: Timeout waiting for lock"
-            return 1
-        fi
-
-        sleep 2
-        ((attempt++))
-    done
-}
-
-function check_lock() {
-    local lock_contents=$(get_lock_contents)
-    local current_owner
-
-    current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
-        echo "ERROR: Cannot read lock file"
-        return 1
-    }
-
-    if [ "${current_owner}" != "${lock_contents}" ]; then
-        echo "ERROR: Invalid lock state - it is held by ${current_owner}"
-        return 1
-    fi
-}
-
-function release_lock() {
-    local lock_contents=$(get_lock_contents)
-    local current_owner
-
-    current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
-        echo "ERROR: Cannot read lock file"
-        return 1
-    }
-
-    if [ "${current_owner}" != "${lock_contents}" ]; then
-        echo "ERROR: Cannot release lock - it is held by ${current_owner}"
-        return 1
-    fi
-
-    if ! ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "rm -f '${LOCK_FILE}'"; then
-        echo "ERROR: Failed to remove lock file"
-        return 1
-    fi
-    echo "Lock released"
 }
 
 function verify_in_git_repo() {
@@ -136,22 +64,15 @@ function uv_sync() {
 
 function run_test() {
     local controller_path=$(get_controller_path)
-    check_lock || return 1
-    ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cd '${controller_path}' && uv run pytest $*"
+    ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cd '${controller_path}' && (
+        flock --exclusive --timeout ${LOCK_TIMEOUT} || { echo 'ERROR: Failed to acquire lock in time'; exit 1; }
+        uv run pytest $*
+    ) 9>'${LOCK_FILE}'"
     return $?
 }
 
-lock_obtained=false
-
 check_ssh_connection || exit 1
 verify_in_git_repo || exit 1
-
-if obtain_lock; then
-    lock_obtained=true
-else
-    exit 1
-fi
-
 copy_to_controller || exit 1
 
 run_test "$@"

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -72,13 +72,10 @@ function run_test() {
     local controller_path=$(get_controller_path)
     SSH_COMMAND="cd '${controller_path}' && (
         flock --exclusive --timeout ${LOCK_TIMEOUT} 9 || { echo 'ERROR: Failed to acquire lock in time'; exit 1; }
-        uv run pytest $*
+        uv run pytest $* && sleep 1
     ) 9>'${LOCK_FILE}'"
     ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "${SSH_COMMAND}"
     status=$?
-
-    # enforce interval between test executions
-    sleep 1
 
     return $status
 }

--- a/software/scripts/runtest.sh
+++ b/software/scripts/runtest.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# TODO: via CLI args
+CONTROLLER_USERNAME='atopile'
+CONTROLLER_HOST="chunky-otter"
+
+LOCK_FILE="/home/atopile/.hil-lock"
+CONTROLLER_PATH_PREFIX="/home/atopile/hil/"
+
+trap 'cleanup' EXIT
+
+function cleanup() {
+    if [ "${lock_obtained:-false}" = true ]; then
+        echo "Cleaning up..."
+        release_lock || true
+    fi
+}
+
+function get_lock_contents() {
+    local username=$(whoami)
+    local hostname=$(hostname)
+    echo "$username@$hostname"
+}
+
+function get_controller_path() {
+    local username=$(whoami)
+    local hostname=$(hostname)
+    echo "${CONTROLLER_PATH_PREFIX}/${username}@${hostname}"
+}
+
+function obtain_lock() {
+    local lock_contents=$(get_lock_contents)
+    local max_attempts=60  # 5 minutes with 5 second sleep
+    local attempt=1
+
+    echo "Attempting to obtain lock..."
+
+    while [ $attempt -le $max_attempts ]; do
+        # TOOD: atomic?
+        if ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "[ ! -f '${LOCK_FILE}' ] && echo '${lock_contents}' > '${LOCK_FILE}'" 2>/dev/null; then
+            echo "Lock obtained"
+            return 0
+        fi
+
+        local current_owner
+        current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
+            echo "ERROR: Cannot read lock file"
+            return 1
+        }
+        echo "Lock is currently held by: ${current_owner} (attempt ${attempt}/${max_attempts})"
+
+        if [ $attempt -eq $max_attempts ]; then
+            echo "ERROR: Timeout waiting for lock"
+            return 1
+        fi
+
+        sleep 2
+        ((attempt++))
+    done
+}
+
+function check_lock() {
+    local lock_contents=$(get_lock_contents)
+    local current_owner
+
+    current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
+        echo "ERROR: Cannot read lock file"
+        return 1
+    }
+
+    if [ "${current_owner}" != "${lock_contents}" ]; then
+        echo "ERROR: Invalid lock state - it is held by ${current_owner}"
+        return 1
+    fi
+}
+
+function release_lock() {
+    local lock_contents=$(get_lock_contents)
+    local current_owner
+
+    current_owner=$(ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cat '${LOCK_FILE}'" 2>/dev/null) || {
+        echo "ERROR: Cannot read lock file"
+        return 1
+    }
+
+    if [ "${current_owner}" != "${lock_contents}" ]; then
+        echo "ERROR: Cannot release lock - it is held by ${current_owner}"
+        return 1
+    fi
+
+    if ! ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "rm -f '${LOCK_FILE}'"; then
+        echo "ERROR: Failed to remove lock file"
+        return 1
+    fi
+    echo "Lock released"
+}
+
+function verify_in_git_repo() {
+    if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+        echo "ERROR: Not in a git repository"
+        return 1
+    fi
+}
+
+function check_ssh_connection() {
+    if ! ssh -q "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "exit" 2>/dev/null; then
+        echo "ERROR: Cannot connect to controller at ${CONTROLLER_USERNAME}@${CONTROLLER_HOST}"
+        return 1
+    fi
+}
+
+function copy_to_controller() {
+    local controller_path=$(get_controller_path)
+
+    if ! ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "mkdir -p '${controller_path}'"; then
+        echo "ERROR: Failed to create target directory on controller"
+        return 1
+    fi
+
+    if ! rsync -aPh --exclude=.git/ --exclude-from=./.gitignore --delete "${PWD}/" "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}:${controller_path}/"; then
+        echo "ERROR: Failed to copy files to controller"
+        return 1
+    fi
+}
+
+function uv_sync() {
+    local controller_path=$(get_controller_path)
+
+    if ! ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cd '${controller_path}' && uv sync"; then
+        echo "ERROR: uv sync failed"
+        return 1
+    fi
+}
+
+function run_test() {
+    local controller_path=$(get_controller_path)
+    check_lock || return 1
+    ssh "${CONTROLLER_USERNAME}@${CONTROLLER_HOST}" "cd '${controller_path}' && uv run pytest $*"
+    return $?
+}
+
+lock_obtained=false
+
+check_ssh_connection || exit 1
+verify_in_git_repo || exit 1
+
+if obtain_lock; then
+    lock_obtained=true
+else
+    exit 1
+fi
+
+copy_to_controller || exit 1
+
+run_test "$@"
+status=$?
+
+exit $status


### PR DESCRIPTION
Adds a test-runner script at `software/scripts/runtest.sh` to safely avoid concurrent tests by different users, and automatically present the generated test report.

Invoke like: `HIL_CONTROLLER_HOST=chunky-otter ./software/scripts/runtest.sh tests/test_demo.py`