### PR TITLE
Correct CAN Controller Interrupt

### DIFF
--- a/ato.yaml
+++ b/ato.yaml
@@ -2,7 +2,6 @@ ato-version: 0.3.0
 
 builds:
   # Project Examples
-
   cellsim-16ch:
     entry: examples/cellsim/cellsim-16ch.ato:CellSim16Ch
 
@@ -61,7 +60,8 @@ builds:
     exclude_targets: [mfg-data]
 
   buck-boost:
-    entry: elec/src/components/texas_instruments_bq25756r_rvr.ato:Texas_Instruments_BQ25756RRVR
+    entry:
+      elec/src/components/texas_instruments_bq25756r_rvr.ato:Texas_Instruments_BQ25756RRVR
     exclude_targets: [mfg-data]
 
   analog-out-4ch:
@@ -69,7 +69,8 @@ builds:
     exclude_targets: [mfg-data]
 
   boost-converter:
-    entry: elec/src/components/texas_instruments_tp_s55340r_ter.ato:Texas_Instruments_TPS55340RTER
+    entry:
+      elec/src/components/texas_instruments_tp_s55340r_ter.ato:Texas_Instruments_TPS55340RTER
     exclude_targets: [mfg-data]
 
   variable-resistor:
@@ -97,11 +98,13 @@ builds:
     exclude_targets: [mfg-data]
 
   usb251b:
-    entry: elec/src/components/microchip_tech_us_b2514b_im2.ato:Microchip_Tech_USB2514B_I_M2
+    entry:
+      elec/src/components/microchip_tech_us_b2514b_im2.ato:Microchip_Tech_USB2514B_I_M2
     exclude_targets: [mfg-data]
 
   current-limit-switch:
-    entry: elec/src/components/diodes_incorporated_ap22653w67.ato:Diodes_Incorporated_AP22653W6_7
+    entry:
+      elec/src/components/diodes_incorporated_ap22653w67.ato:Diodes_Incorporated_AP22653W6_7
     exclude_targets: [mfg-data]
 
   micro-vault:
@@ -109,34 +112,36 @@ builds:
     exclude_targets: [mfg-data]
 
   ads1219ipwr:
-    entry: elec/src/components/texas_instruments_ads1219ipwr.ato:Texas_Instruments_ADS1219IPWR
+    entry:
+      elec/src/components/texas_instruments_ads1219ipwr.ato:Texas_Instruments_ADS1219IPWR
     exclude_targets: [mfg-data]
 
   ref5050aidr:
-    entry: elec/src/components/texas_instruments_ref5050aidr.ato:Texas_Instruments_REF5050AIDR
+    entry:
+      elec/src/components/texas_instruments_ref5050aidr.ato:Texas_Instruments_REF5050AIDR
     exclude_targets: [mfg-data]
 
   micro-vault-dev-board:
     entry: elec/src/blocks/micro_vault.ato:MicroVaultDevBoard
 
 dependencies:
-  - name: ldk220m-r
-    version_spec:
-    link_broken: false
-    path: .ato/modules/ldk220m-r
-    source:
-  - name: saleae-header
-    version_spec: "@d8281da01a1efdde7779499647c31a10ab47ec45"
-    link_broken: false
-    path: .ato/modules/saleae-header
-    source:
-  - name: xt-connectors
-    version_spec:
-    link_broken: false
-    path: .ato/modules/xt-connectors
-    source:
-  - name: https://github.com/atopile/lv2842xlvddcr.git
-    version_spec: "@ac20c5b8415de66fa9af8c74218dd52d0c579ad6"
-    link_broken: false
-    path: .ato/modules/lv2842xlvddcr.git
-    source:
+- name: ldk220m-r
+  version_spec:
+  link_broken: false
+  path: .ato/modules/ldk220m-r
+  source:
+- name: saleae-header
+  version_spec: '@d8281da01a1efdde7779499647c31a10ab47ec45'
+  link_broken: false
+  path: .ato/modules/saleae-header
+  source:
+- name: xt-connectors
+  version_spec:
+  link_broken: false
+  path: .ato/modules/xt-connectors
+  source:
+- name: https://github.com/atopile/lv2842xlvddcr.git
+  version_spec: '@ac20c5b8415de66fa9af8c74218dd52d0c579ad6'
+  link_broken: false
+  path: .ato/modules/lv2842xlvddcr.git
+  source:

--- a/elec/src/blocks/coms-can.ato
+++ b/elec/src/blocks/coms-can.ato
@@ -1,10 +1,12 @@
 import ElectricPower, Capacitor, Resistor, SPI, ElectricLogic
+
 from "interfaces.ato" import CAN
 
 from "components/ylptec_b0505s2wr3.ato" import YLPTEC_B0505S_2WR3
 from "components/nexperia_pe_sd1c_an215.ato" import Nexperia_PESD1CAN_215
 from "components/texas_instruments_is_o1044b_dr.ato" import Texas_Instruments_ISO1044BDR
 from "components/microchip_tech_mc_p2518f_dteqb_b.ato" import Microchip_Tech_MCP2518FDT_E_QBB
+
 
 module ComsCANISO:
     """
@@ -13,15 +15,24 @@ module ComsCANISO:
     - Up to 5Mbps (CAN FD)
     - Isolated CAN interface (1KV)
     """
-    # external interfaces
+    # Please configure me!
+    ## SPI, CS and Interrupt are all required to connect to the controller
     spi = new SPI
     spi_cs = new ElectricLogic
-    can = new CAN
     interrupt = new ElectricLogic
+
+    ## External Network Connection
+    can = new CAN
+
+    ## Provide power
     power_3v3 = new ElectricPower
     power_5v = new ElectricPower
 
-    # internal interfaces
+    ## Specialize termination if CAN termination is required
+    termination = new CANTerminationInterface
+
+    # Internals of the module
+
     _power_5v_iso = new ElectricPower
 
     # Components
@@ -29,7 +40,6 @@ module ComsCANISO:
     controller = new Microchip_Tech_MCP2518FDT_E_QBB
     transceiver = new Texas_Instruments_ISO1044BDR
     protection = new Nexperia_PESD1CAN_215
-    termination = new CANTermination
 
     # Interrupts
     interrupt ~ controller.interrupt_h
@@ -56,13 +66,23 @@ module ComsCANISO:
     termination.can ~ can
     termination.gnd ~ _power_5v_iso.gnd
 
-module CANTermination:
+
+module CANTerminationInterface:
     """
-    CAN termination 120Ohm with center tap capacitor
+    Generic CAN termination interface
     """
     can = new CAN
-    signal gnd
+    signal gnd  # ground of the power reference of the CAN interface
 
+
+module SplitCANTermination from CANTerminationInterface:
+    """
+    CAN termination 120Ohm with center tap capacitor
+
+    Split termination improves the electromagnetic emissions
+    behavior of the network by eliminating fluctuations in the
+    bus common-mode voltages at the start and end of message transmissions.
+    """
     # Components
     resistor_can_high = new Resistor
     resistor_can_high.resistance = 60ohm +/- 2%

--- a/elec/src/blocks/controller-cm5.ato
+++ b/elec/src/blocks/controller-cm5.ato
@@ -35,12 +35,10 @@ module ControllerCM5:
     spi0 = new SPI
     spi0_cs0 = new ElectricLogic
     spi0_cs1 = new ElectricLogic
-    spi0_int = new ElectricLogic
 
     spi0 ~ cm5.spi0
     spi0_cs0 ~ cm5.spi0_cs0
     spi0_cs1 ~ cm5.spi0_cs1
-    spi0_int ~ cm5.spi0_int
 
     # USB
     usb2 = new USB2_0

--- a/elec/src/components/cm5/cm5.py
+++ b/elec/src/components/cm5/cm5.py
@@ -45,7 +45,6 @@ class CM5_MINIMAL(Module):
     spi0: F.SPI
     spi0_cs0: F.ElectricLogic
     spi0_cs1: F.ElectricLogic
-    spi0_int: F.ElectricLogic
 
     # LED
     led_data: F.ElectricLogic
@@ -145,9 +144,6 @@ class CM5_MINIMAL(Module):
 
         # LED Data
         self.led_data.connect(self.gpio[20])
-
-        # SPI Interrupt
-        self.spi0_int.connect(self.gpio[6])
 
         # UART
         self.uart0.base_uart.tx.connect(self.gpio[14])
@@ -275,6 +271,37 @@ class CM5_MINIMAL(Module):
 
         for gpio_num, pin_num in gpio_mapping.items():
             self.gpio[gpio_num].line.connect(self.hdi_a.pins[pin_num])
+
+        # TODO: Remove this once we have access
+        # to the GPIOs via square brackets
+        self.gpio_0 = self.gpio[0]
+        self.gpio_1 = self.gpio[1]
+        self.gpio_2 = self.gpio[2]
+        self.gpio_3 = self.gpio[3]
+        self.gpio_4 = self.gpio[4]
+        self.gpio_5 = self.gpio[5]
+        self.gpio_6 = self.gpio[6]
+        self.gpio_7 = self.gpio[7]
+        self.gpio_8 = self.gpio[8]
+        self.gpio_9 = self.gpio[9]
+        self.gpio_10 = self.gpio[10]
+        self.gpio_11 = self.gpio[11]
+        self.gpio_12 = self.gpio[12]
+        self.gpio_13 = self.gpio[13]
+        self.gpio_14 = self.gpio[14]
+        self.gpio_15 = self.gpio[15]
+        self.gpio_16 = self.gpio[16]
+        self.gpio_17 = self.gpio[17]
+        self.gpio_18 = self.gpio[18]
+        self.gpio_19 = self.gpio[19]
+        self.gpio_20 = self.gpio[20]
+        self.gpio_21 = self.gpio[21]
+        self.gpio_22 = self.gpio[22]
+        self.gpio_23 = self.gpio[23]
+        self.gpio_24 = self.gpio[24]
+        self.gpio_25 = self.gpio[25]
+        self.gpio_26 = self.gpio[26]
+        self.gpio_27 = self.gpio[27]
 
         # GPIO Reference voltage setter
         if self.gpio_ref_voltage == GPIO_Ref_Voltages.V1_8:

--- a/examples/cellsim/cellsim-16ch.ato
+++ b/examples/cellsim/cellsim-16ch.ato
@@ -108,7 +108,7 @@ module CellSim16Ch:
     # SPI
     hil_core.controller.spi0 ~ can_controller.spi
     hil_core.controller.spi0_cs0 ~ can_controller.spi_cs
-    hil_core.controller.spi0_int ~ can_controller.interrupt
+    hil_core.controller.cm5.gpio_6 ~ can_controller.interrupt
 
     # Connector
     can_connector = new JSTGH4Pin

--- a/examples/cellsim/cellsim-16ch.ato
+++ b/examples/cellsim/cellsim-16ch.ato
@@ -1,7 +1,7 @@
 from "blocks/hil-core.ato" import HILCore
 from "blocks/cellsim-8ch.ato" import CellSim8Ch
 from "blocks/analog-out-4ch.ato" import AnalogOut4ch
-from "blocks/coms-can.ato" import ComsCANISO
+from "blocks/coms-can.ato" import ComsCANISO, SplitCANTermination
 from "blocks/multiplexer-i2c-8ch.ato" import MultiplexerI2C8Ch
 from "blocks/debug-saleae.ato" import DebugSaleae
 from "components/banana-power.ato" import BananaPower
@@ -99,6 +99,7 @@ module CellSim16Ch:
 
     # CAN Interface
     can_controller = new ComsCANISO
+    can_controller.termination -> SplitCANTermination
 
     # Power
     hil_core.power_5v ~ can_controller.power_5v


### PR DESCRIPTION
GPIO 6 isn't an SPI interrupt, it's just a GPIO that happens to be useful as an interrupt for the CAN controller